### PR TITLE
Remove the logic that tried to get the outgoing configurations. This is too fragile...

### DIFF
--- a/tapmoc-gradle-plugin/api/tapmoc-gradle-plugin.api
+++ b/tapmoc-gradle-plugin/api/tapmoc-gradle-plugin.api
@@ -16,7 +16,9 @@ public abstract interface class tapmoc/TapmocExtension {
 	public abstract fun checkDependencies ()V
 	public abstract fun checkDependencies (Ltapmoc/Severity;)V
 	public abstract fun checkJavaClassFiles (Ljava/lang/String;Ltapmoc/Severity;)V
+	public abstract fun checkJavaClassFiles (Ltapmoc/Severity;)V
 	public abstract fun checkKotlinMetadata (Ljava/lang/String;Ltapmoc/Severity;)V
+	public abstract fun checkKotlinMetadata (Ltapmoc/Severity;)V
 	public abstract fun checkKotlinStdlibs (Ljava/lang/String;Ltapmoc/Severity;)V
 	public abstract fun checkKotlinStdlibs (Ltapmoc/Severity;)V
 	public abstract fun checkRuntimeDependencies (Ltapmoc/Severity;)V

--- a/tapmoc-gradle-plugin/api/tapmoc-gradle-plugin.api
+++ b/tapmoc-gradle-plugin/api/tapmoc-gradle-plugin.api
@@ -5,7 +5,6 @@ public final class tapmoc/CompatibilityKt {
 
 public final class tapmoc/Severity : java/lang/Enum {
 	public static final field ERROR Ltapmoc/Severity;
-	public static final field IGNORE Ltapmoc/Severity;
 	public static final field WARNING Ltapmoc/Severity;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Ltapmoc/Severity;
@@ -16,8 +15,9 @@ public abstract interface class tapmoc/TapmocExtension {
 	public abstract fun checkApiDependencies (Ltapmoc/Severity;)V
 	public abstract fun checkDependencies ()V
 	public abstract fun checkDependencies (Ltapmoc/Severity;)V
-	public abstract fun checkJavaClassFiles (Ltapmoc/Severity;)V
-	public abstract fun checkKotlinMetadata (Ltapmoc/Severity;)V
+	public abstract fun checkJavaClassFiles (Ljava/lang/String;Ltapmoc/Severity;)V
+	public abstract fun checkKotlinMetadata (Ljava/lang/String;Ltapmoc/Severity;)V
+	public abstract fun checkKotlinStdlibs (Ljava/lang/String;Ltapmoc/Severity;)V
 	public abstract fun checkKotlinStdlibs (Ltapmoc/Severity;)V
 	public abstract fun checkRuntimeDependencies (Ltapmoc/Severity;)V
 	public abstract fun gradle (Ljava/lang/String;)V

--- a/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/TapmocExtension.kt
+++ b/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/TapmocExtension.kt
@@ -72,9 +72,10 @@ interface TapmocExtension {
    *
    * This checks the [class file version](https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.1).
    *
-   * @param severity The severity level for the check. Defaults to `Severity.IGNORE`.
+   * @param configuration the name of the configuration to check. A new resolvable configuration will be created that extends from that configuration.
+   * @param severity The severity level for the check.
    */
-  fun checkJavaClassFiles(severity: Severity)
+  fun checkJavaClassFiles(configuration: String, severity: Severity)
 
   /**
    * Checks that the api dependencies Kotlin metadata is compatible with the target Kotlin version.
@@ -82,23 +83,51 @@ interface TapmocExtension {
    * Thanks to Kotlin [best effort n + 1 forward compatibility guarantee](https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format),
    * dependencies may contain `kotlinTarget + 1` metadata.
    *
-   * @param severity The severity level for the check. Defaults to `Severity.IGNORE`.
+   * @param configuration the name of the configuration to check. A new resolvable configuration will be created that extends from that configuration.
+   * @param severity The severity level for the check.
    */
-  fun checkKotlinMetadata(severity: Severity)
+  fun checkKotlinMetadata(configuration: String, severity: Severity)
 
   /**
    * Checks that the runtime dependencies do not contain a version of `kotlin-stdlib` higher than the target Kotlin version.
    *
-   * In most cases, `kotlin-stdlib` can be safely upgraded and this check is disabled by default.
+   * In most cases, `kotlin-stdlib` can be safely upgraded, and this check is disabled by default.
    *
-   * Enable it if your runtime forces a given version of `kotlin-stdlib`. This is the notably case for Gradle plugins.
+   * Enable it if your runtime forces a given version of `kotlin-stdlib`. This is the case for Gradle plugins in particular.
    *
-   * @param severity The severity level for the check. Defaults to `Severity.IGNORE`.
+   * @param configuration the name of the configuration to check. A new resolvable configuration will be created that extends from that configuration.
+   * @param severity The severity level for the check.
+   */
+  fun checkKotlinStdlibs(configuration: String, severity: Severity)
+
+  /**
+   * This is equivalent to calling `checkKotlinStdlibs(runtimeConfiguration, severity)`.
+   *
+   * Where:
+   * - `runtimeConfiguration` is the outgoing variant containing the runtime dependencies (typically, "apiElements").
+   *
+   * The actual name of the configurations is guessed depending on the applied plugins (Jvm/kmp/android/etc...).
+   *
+   * If the guessing didn't work, call [checkKotlinStdlibs] manually.
+   *
+   * @see checkKotlinStdlibs
    */
   fun checkKotlinStdlibs(severity: Severity)
 
+
   /**
-   * This is equivalent to calling `checkJavaClassFiles(severity)` and `checkKotlinMetadata(severity)`.
+   * This is equivalent to calling `checkJavaClassFiles(runtimeConfiguration, severity)` and `checkKotlinMetadata(apiConfiguration, severity)`.
+   *
+   * Where:
+   * - `runtimeConfiguration` is the outgoing variant containing the runtime dependencies (typically, "apiElements").
+   * - `apiConfiguration` is the outgoing variant containing the API dependencies (typically, "runtimeElements").
+   *
+   * The actual name of the configurations is guessed depending on the applied plugins (Jvm/kmp/android/etc...).
+   *
+   * If the guessing didn't work, call [checkJavaClassFiles] and [checkKotlinMetadata] manually.
+   *
+   * Note: this doesn't call `checkKotlinStdlibs(runtimeConfigurationm, severity)` as kotlin-stdlib is usually upgraded at runtime. One notable exception is Gradle plugins.
+   * If you are developing a Gradle plugin, you may want to call `checkKotlinStdlibs(severity)`.
    *
    * @see checkJavaClassFiles
    * @see checkKotlinMetadata
@@ -120,7 +149,6 @@ interface TapmocExtension {
 }
 
 enum class Severity {
-  IGNORE,
   WARNING,
   ERROR
 }

--- a/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/TapmocExtension.kt
+++ b/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/TapmocExtension.kt
@@ -78,6 +78,20 @@ interface TapmocExtension {
   fun checkJavaClassFiles(configuration: String, severity: Severity)
 
   /**
+   * This is equivalent to calling `checkJavaClassFiles(runtimeConfiguration, severity)`.
+   *
+   * Where:
+   * - `runtimeConfiguration` is the outgoing variant containing the runtime dependencies (typically, "runtimeElements").
+   *
+   * The actual name of the configurations is guessed depending on the applied plugins (Jvm/kmp/android/etc...).
+   *
+   * If the guessing didn't work, call [checkJavaClassFiles] manually.
+   *
+   * @see checkJavaClassFiles
+   */
+  fun checkJavaClassFiles(severity: Severity)
+
+  /**
    * Checks that the api dependencies Kotlin metadata is compatible with the target Kotlin version.
    *
    * Thanks to Kotlin [best effort n + 1 forward compatibility guarantee](https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format),
@@ -87,6 +101,20 @@ interface TapmocExtension {
    * @param severity The severity level for the check.
    */
   fun checkKotlinMetadata(configuration: String, severity: Severity)
+
+  /**
+   * This is equivalent to calling `checkKotlinMetadata(apiConfiguration, severity)`.
+   *
+   * Where:
+   * - `apiConfiguration` is the outgoing variant containing the runtime dependencies (typically, "apiConfiguration").
+   *
+   * The actual name of the configurations is guessed depending on the applied plugins (Jvm/kmp/android/etc...).
+   *
+   * If the guessing didn't work, call [checkKotlinMetadata] manually.
+   *
+   * @see checkKotlinMetadata
+   */
+  fun checkKotlinMetadata(severity: Severity)
 
   /**
    * Checks that the runtime dependencies do not contain a version of `kotlin-stdlib` higher than the target Kotlin version.
@@ -104,7 +132,7 @@ interface TapmocExtension {
    * This is equivalent to calling `checkKotlinStdlibs(runtimeConfiguration, severity)`.
    *
    * Where:
-   * - `runtimeConfiguration` is the outgoing variant containing the runtime dependencies (typically, "apiElements").
+   * - `runtimeConfiguration` is the outgoing variant containing the runtime dependencies (typically, "runtimElements").
    *
    * The actual name of the configurations is guessed depending on the applied plugins (Jvm/kmp/android/etc...).
    *

--- a/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/internal/TapmocExtensionImpl.kt
+++ b/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/internal/TapmocExtensionImpl.kt
@@ -1,14 +1,13 @@
 package tapmoc.internal
 
-import org.gradle.api.NamedDomainObjectSet
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
+import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.attributes.Attribute
-import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.Usage
+import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import tapmoc.Severity
 import tapmoc.TapmocExtension
@@ -19,128 +18,14 @@ import tapmoc.task.registerTapmocCheckKotlinMetadataVersionsTask
 import tapmoc.task.registerTapmocCheckKotlinStdlibVersionsTask
 
 internal abstract class TapmocExtensionImpl(private val project: Project) : TapmocExtension {
-  abstract val javaClassFilesSeverity: Property<Severity>
-  abstract val kotlinMetadataSeverity: Property<Severity>
-  abstract val kotlinStdlibSeverity: Property<Severity>
-
   abstract val kotlinVersionProvider: Property<String>
   abstract val javaVersionProvider: Property<Int>
 
-  init {
-    javaClassFilesSeverity.convention(Severity.IGNORE)
-    kotlinMetadataSeverity.convention(Severity.IGNORE)
-    kotlinStdlibSeverity.convention(Severity.IGNORE)
-
-    val apiDependencies = configuration("tapmocApiDependencies", Usage.JAVA_API)
-    val runtimeDependencies = configuration("tapmocRuntimeDependencies", Usage.JAVA_RUNTIME)
-
-    val checkJavaClassFiles = project.registerTapmocCheckClassFileVersionsTask(
-      warningAsError = javaClassFilesSeverity.map { it == Severity.ERROR },
-      javaVersion = javaVersionProvider,
-      jarFiles = project.files(apiDependencies, runtimeDependencies)
-    )
-    checkJavaClassFiles.configure {
-      it.enabled = javaClassFilesSeverity.get() != Severity.IGNORE
-    }
-
-    val checkKotlinMetadatas = project.registerTapmocCheckKotlinMetadataVersionsTask(
-      warningAsError = kotlinMetadataSeverity.map { it == Severity.ERROR },
-      kotlinVersion = kotlinVersionProvider,
-      files = project.files(apiDependencies),
-    )
-    checkKotlinMetadatas.configure {
-      it.enabled = kotlinMetadataSeverity.get() != Severity.IGNORE
-    }
-
-    val checkKotlinStdlibs = project.registerTapmocCheckKotlinStdlibVersionsTask(
-      warningAsError = kotlinStdlibSeverity.map { it == Severity.ERROR },
-      kotlinVersion = kotlinVersionProvider,
-      kotlinStdlibVersions = runtimeDependencies.map {
-        it.incoming.resolutionResult.allComponents
-          .mapNotNull { (it.id as? ModuleComponentIdentifier) }
-          .filter {
-            it.group == "org.jetbrains.kotlin" && it.module == "kotlin-stdlib"
-          }.map {
-            it.version
-          }.toSet()
-      },
-    )
-    checkKotlinStdlibs.configure {
-      it.enabled = kotlinStdlibSeverity.get() != Severity.IGNORE
-    }
-
+  private fun addToCheckTask(taskProvider: TaskProvider<*>) {
     project.plugins.withType(LifecycleBasePlugin::class.java) {
       project.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME).configure {
-        it.dependsOn(checkKotlinStdlibs)
-        it.dependsOn(checkKotlinMetadatas)
-        it.dependsOn(checkJavaClassFiles)
+        it.dependsOn(taskProvider)
       }
-    }
-  }
-
-  /**
-   * Returns a Provider that configures the underlying configuration the first time
-   * it is accessed.
-   *
-   * We cannot use the regular `.configure{}` because the generated accessors call it too
-   * early.
-   * We also need it to be lazy because AGP/KGP set their attributes later in the lifecycle.
-   *
-   * See https://github.com/gradle/gradle/issues/36147
-   */
-  private fun configuration(name: String, usage: String): Provider<Configuration> {
-    val provider = project.configurations.register(name) {
-      it.isCanBeConsumed = false
-      it.isCanBeResolved = true
-      it.isVisible = false
-
-      it.attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, usage))
-      /**
-       * For Android, select "release" by default. This is probably not 100% correct, but fixes errors like those:
-       *
-       * ```
-       * Could not determine the dependencies of task ':openfeedback-m3:tapmocCheckClassFileVersions'.
-       * > Could not resolve all dependencies for configuration ':openfeedback-m3:tapmocRuntimeDependencies'.
-       *    > Could not resolve project :openfeedback-resources.
-       *      Required by:
-       *          project :openfeedback-m3
-       *       > The consumer was configured to find a component for use during runtime. However we cannot choose between the following variants of project :openfeedback-resources:
-       *           - debugRuntimeElements
-       *           - releaseRuntimeElements
-       *         All of them match the consumer attributes:
-       *           - Variant 'debugRuntimeElements' capability 'io.openfeedback:openfeedback-resources:1.0.0-alpha.5-SNAPSHOT' declares a component for use during runtime:
-       *               - Unmatched attributes:
-       *                   - Provides a library but the consumer didn't ask for it
-       *                   - Provides attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '8.9.0' but the consumer didn't ask for it
-       *                   - Provides attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'debug' but the consumer didn't ask for it
-       *                   - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'debug' but the consumer didn't ask for it
-       *                   - Provides attribute 'org.gradle.jvm.environment' with value 'android' but the consumer didn't ask for it
-       *                   - Provides attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm' but the consumer didn't ask for it
-       *           - Variant 'releaseRuntimeElements' capability 'io.openfeedback:openfeedback-resources:1.0.0-alpha.5-SNAPSHOT' declares a component for use during runtime:
-       *               - Unmatched attributes:
-       *                   - Provides a library but the consumer didn't ask for it
-       *                   - Provides attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '8.9.0' but the consumer didn't ask for it
-       *                   - Provides attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release' but the consumer didn't ask for it
-       *                   - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'release' but the consumer didn't ask for it
-       *                   - Provides attribute 'org.gradle.jvm.environment' with value 'android' but the consumer didn't ask for it
-       *                   - Provides attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm' but the consumer didn't ask for it
-       * ```
-       *
-       * I'm expecting the attributes to be ignored in the other cases because "missing attributes are a match" 🤞
-       */
-      it.attributes.attribute(Attribute.of("com.android.build.gradle.internal.attributes.VariantAttr", String::class.java), "release")
-      it.attributes.attribute(Attribute.of("artifactType", String::class.java), "jar")
-    }
-
-    var firstTime = true
-    return project.provider {
-      if (firstTime) {
-        project.getConfigurations(usage).forEach {
-          provider.get().extendsFrom(it)
-        }
-        firstTime = false
-      }
-      provider.get()
     }
   }
 
@@ -168,26 +53,129 @@ internal abstract class TapmocExtensionImpl(private val project: Project) : Tapm
     return kotlinVersionForGradle(parseGradleMajorVersion(gradleVersion))
   }
 
-  override fun checkJavaClassFiles(severity: Severity) {
-    javaClassFilesSeverity.set(severity)
+  private fun configurationFor(configuration: String): NamedDomainObjectProvider<Configuration> {
+    val name = lowerCameCase("tapmoc", configuration)
+    var tapmocConfiguration = try {
+      project.configurations.named(name)
+    } catch (_: UnknownDomainObjectException) {
+      null
+    }
+    if (tapmocConfiguration == null) {
+      tapmocConfiguration = project.configurations.register(name) {
+        it.isCanBeConsumed = false
+        it.isCanBeResolved = true
+        it.isVisible = false
+        it.extendsFrom(project.configurations.getByName(configuration))
+      }
+    }
+    return tapmocConfiguration
   }
 
-  override fun checkKotlinMetadata(severity: Severity) {
-    kotlinMetadataSeverity.set(severity)
+  private fun fileCollectionFor(configuration: String): FileCollection {
+    return project.files(configurationFor(configuration))
+  }
+
+  override fun checkJavaClassFiles(configuration: String, severity: Severity) {
+    val checkJavaClassFiles = project.registerTapmocCheckClassFileVersionsTask(
+      taskName = lowerCameCase("tapmoc", "check", configuration, "JavaClassFiles"),
+      warningAsError = project.provider { severity == Severity.ERROR },
+      javaVersion = javaVersionProvider,
+      jarFiles = project.files(fileCollectionFor(configuration))
+    )
+    addToCheckTask(checkJavaClassFiles)
+  }
+
+  override fun checkKotlinMetadata(configuration: String, severity: Severity) {
+    val checkKotlinMetadatas = project.registerTapmocCheckKotlinMetadataVersionsTask(
+      taskName = lowerCameCase("tapmoc", "check", configuration, "KotlinMetadata"),
+      warningAsError = project.provider { severity == Severity.ERROR },
+      kotlinVersion = kotlinVersionProvider,
+      files = fileCollectionFor(configuration),
+    )
+    addToCheckTask(checkKotlinMetadatas)
+  }
+
+  override fun checkKotlinStdlibs(configuration: String, severity: Severity) {
+    val checkKotlinStdlibs = project.registerTapmocCheckKotlinStdlibVersionsTask(
+      taskName = lowerCameCase("tapmoc", "check", configuration, "KotlinStdlib"),
+      warningAsError = project.provider { severity == Severity.ERROR },
+      kotlinVersion = kotlinVersionProvider,
+      kotlinStdlibVersions = configurationFor(configuration).map {
+        it.incoming.resolutionResult.allComponents
+          .mapNotNull { (it.id as? ModuleComponentIdentifier) }
+          .filter {
+            it.group == "org.jetbrains.kotlin" && it.module == "kotlin-stdlib"
+          }.map {
+            it.version
+          }.toSet()
+      },
+    )
+
+    addToCheckTask(checkKotlinStdlibs)
   }
 
   override fun checkKotlinStdlibs(severity: Severity) {
-    kotlinStdlibSeverity.set(severity)
+    reactToPlugins(
+      onApi = { },
+      onRuntime = { checkKotlinStdlibs(it, severity) }
+    )
   }
-
   override fun checkDependencies() {
     checkDependencies(Severity.ERROR)
   }
 
+  private fun reactToPlugins(onApi: (String) -> Unit, onRuntime: (String) -> Unit) {
+    var hasJava = false
+    var hasKotlinJvm = false
+    var hasKotlinMultiplatform = false
+
+    project.pluginManager.withPlugin("java") {
+      if (!hasKotlinJvm) {
+        onApi("apiElements")
+        onRuntime("runtimeElements")
+      }
+      hasJava = true
+    }
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+      if (!hasJava) {
+        onApi("apiElements")
+        onRuntime("runtimeElements")
+      }
+      hasKotlinJvm = true
+    }
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+      onApi("jvmApiElements")
+      onRuntime("jvmRuntimeElements")
+
+      hasKotlinMultiplatform = true
+    }
+    project.pluginManager.withPlugin("com.android.library") {
+      onApi("releaseApiElements")
+      onRuntime("releaseRuntimeElements")
+
+      hasKotlinMultiplatform = true
+    }
+
+    project.afterEvaluate {
+      if (!hasJava && !hasKotlinJvm && !hasKotlinMultiplatform) {
+        val task = project.tasks.findByName("tapmocError")
+        if (task == null) {
+          val task2 = project.tasks.register("tapmocError") {
+            it.doFirst {
+              error("Tapmoc: checkDependencies() didn't find any supported plugin. Please call `checkJavaClassFiles()` and `checkKotlinMetadata()` instead.")
+            }
+          }
+          addToCheckTask(task2)
+        }
+      }
+    }
+  }
   @Suppress("DEPRECATION")
   override fun checkDependencies(severity: Severity) {
-    checkJavaClassFiles(severity)
-    checkKotlinMetadata(severity)
+    reactToPlugins(
+      onApi = { checkKotlinMetadata(it, severity) },
+      onRuntime = { checkJavaClassFiles(it, severity) }
+    )
   }
 
   @Deprecated(
@@ -209,33 +197,15 @@ internal abstract class TapmocExtensionImpl(private val project: Project) : Tapm
   }
 }
 
-/**
- * Retrieves the outgoing configurations for this project.
- *
- * We currently only check the JVM configurations.
- */
-private fun Project.getConfigurations(usage: String): NamedDomainObjectSet<Configuration> {
-  return configurations.matching {
-    it.isCanBeConsumed
-        && it.attributes.getAttribute(Usage.USAGE_ATTRIBUTE)?.name == usage
-        /**
-         * releaseSourcesElements declare the `java-runtime` attribute, and we need to set the category to remove it:
-         *
-         * ```
-         * Attributes
-         *     - com.android.build.api.attributes.AgpVersionAttr          = 8.12.0
-         *     - com.android.build.api.attributes.BuildTypeAttr           = release
-         *     - com.android.build.gradle.internal.attributes.VariantAttr = release
-         *     - org.gradle.category                                      = documentation
-         *     - org.gradle.dependency.bundling                           = external
-         *     - org.gradle.docstype                                      = sources
-         *     - org.gradle.jvm.environment                               = android
-         *     - org.gradle.libraryelements                               = jar
-         *     - org.gradle.usage                                         = java-runtime
-         *     - org.jetbrains.kotlin.platform.type                       = androidJvm
-         * ```
-         */
-        && it.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name != Category.DOCUMENTATION
-  }
+private fun lowerCameCase(vararg components: String): String {
+  return components
+    .filter { it.isNotEmpty() }
+    .mapIndexed { index, component ->
+      if (index == 0) {
+        component.replaceFirstChar { it.lowercase() }
+      } else {
+        component.replaceFirstChar { it.uppercase() }
+      }
+    }
+    .joinToString("")
 }
-

--- a/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/internal/TapmocExtensionImpl.kt
+++ b/tapmoc-gradle-plugin/src/main/kotlin/tapmoc/internal/TapmocExtensionImpl.kt
@@ -85,6 +85,14 @@ internal abstract class TapmocExtensionImpl(private val project: Project) : Tapm
     addToCheckTask(checkJavaClassFiles)
   }
 
+  override fun checkJavaClassFiles(severity: Severity) {
+    reactToPlugins(
+      onApi = {},
+      onRuntime = { checkJavaClassFiles(it, severity)}
+    )
+  }
+
+
   override fun checkKotlinMetadata(configuration: String, severity: Severity) {
     val checkKotlinMetadatas = project.registerTapmocCheckKotlinMetadataVersionsTask(
       taskName = lowerCameCase("tapmoc", "check", configuration, "KotlinMetadata"),
@@ -94,6 +102,14 @@ internal abstract class TapmocExtensionImpl(private val project: Project) : Tapm
     )
     addToCheckTask(checkKotlinMetadatas)
   }
+
+  override fun checkKotlinMetadata(severity: Severity) {
+    reactToPlugins(
+      onApi = {checkKotlinMetadata(it, severity) },
+      onRuntime = {}
+    )
+  }
+
 
   override fun checkKotlinStdlibs(configuration: String, severity: Severity) {
     val checkKotlinStdlibs = project.registerTapmocCheckKotlinStdlibVersionsTask(
@@ -120,6 +136,7 @@ internal abstract class TapmocExtensionImpl(private val project: Project) : Tapm
       onRuntime = { checkKotlinStdlibs(it, severity) }
     )
   }
+
   override fun checkDependencies() {
     checkDependencies(Severity.ERROR)
   }


### PR DESCRIPTION
Instead, react to known plugins and offer low level apis to pass a configuration name explicitely
